### PR TITLE
Add messages to Pool model

### DIFF
--- a/lib/fog/compute/xen_server.rb
+++ b/lib/fog/compute/xen_server.rb
@@ -136,6 +136,45 @@ module Fog
       request :shutdown_host
       request :sync_data_host
       
+      # pool
+      request :apply_edition_pool
+      request :certificate_install_pool
+      request :certificate_list_pool
+      request :certificate_sync_pool
+      request :certificate_uninstall_pool
+      request :create_new_blob_pool
+      request :create_vlan_from_pif_pool
+      request :create_vlan_pool
+      request :crl_install_pool
+      request :crl_list_pool
+      request :crl_uninstall_pool
+      request :designate_new_master_pool
+      request :detect_nonhomogeneous_external_auth_pool
+      request :disable_external_auth_pool
+      request :disable_ha_pool
+      request :disable_local_storage_caching_pool
+      request :disable_redo_log_pool
+      request :eject_pool
+      request :emergency_reset_master_pool
+      request :emergency_transition_to_master_pool
+      request :enable_external_auth_pool
+      request :enable_ha_pool
+      request :enable_local_storage_caching_pool
+      request :enable_redo_log_pool
+      request :get_license_state_pool
+      request :ha_compute_hypothetical_max_host_failures_to_tolerate_pool
+      request :ha_compute_max_host_failures_to_tolerate_pool
+      request :ha_compute_vm_failover_plan_pool
+      request :ha_failover_plan_exists_pool
+      request :ha_prevent_restarts_for_pool
+      request :join_force_pool
+      request :join_pool
+      request :recover_slaves_pool
+      request :send_test_post_pool
+      request :set_ha_host_failures_to_tolerate_pool
+      request :set_vswitch_controller_pool
+      request :sync_database_pool
+      
       # VM
       request :add_to_vcpus_params_live_server
       request :assert_agile_server

--- a/lib/fog/compute/xen_server/models/pool.rb
+++ b/lib/fog/compute/xen_server/models/pool.rb
@@ -41,6 +41,22 @@ module Fog
           has_one_identity    :suspend_image_sr, :storage_repositories,   :aliases => :suspend_image_SR,  :as => :suspend_image_SR
 
           alias_method :default_storage_repository, :default_sr
+          methods = %w{ certificate_install certificate_list certificate_sync certificate_uninstall create_vlan \
+                        create_vlan_from_pif crl_install crl_list crl_uninstall designate_new_master disable_ha \
+                        disable_redo_log emergency_reset_master emergency_transition_to_master enable_ha \
+                        enable_redo_log ha_compute_hypothetical_max_host_failures_to_tolerate \
+                        ha_compute_max_host_failures_to_tolerate ha_compute_vm_failover_plan \
+                        ha_failover_plan_exists ha_prevent_restarts_for join join_force recover_slaves \
+                        send_test_post set_vswitch_controller sync_database
+                      }
+
+          # would be much simpler just call __callee__ on request without reference
+          # instead of __method__ and set an alias for each method defined on
+          # methods, just creating a method for each one, so we can keep compatability
+          # with ruby 1.8.7 that does not have __callee__
+          methods.each do |method|
+            define_method(method.to_sym) { |*args| service.send("#{__method__}_#{provider_class.downcase}", *args) }
+          end
         end
       end
     end

--- a/lib/fog/compute/xen_server/requests/apply_edition_pool.rb
+++ b/lib/fog/compute/xen_server/requests/apply_edition_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def apply_edition_pool(ref, edition)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.apply_edition' }, ref, edition)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/certificate_install_pool.rb
+++ b/lib/fog/compute/xen_server/requests/certificate_install_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def certificate_install_pool(name, cert)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.certificate_install' }, name, cert)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/certificate_list_pool.rb
+++ b/lib/fog/compute/xen_server/requests/certificate_list_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def certificate_list_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.certificate_list')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/certificate_sync_pool.rb
+++ b/lib/fog/compute/xen_server/requests/certificate_sync_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def certificate_sync_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.certificate_sync')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/certificate_uninstall_pool.rb
+++ b/lib/fog/compute/xen_server/requests/certificate_uninstall_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def certificate_uninstall_pool(string)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.certificate_uninstall' }, string)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/create_new_blob_pool.rb
+++ b/lib/fog/compute/xen_server/requests/create_new_blob_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def create_new_blob_pool(ref, name, mime_type, public)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.create_new_blob' }, ref, name, mime_type, public)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/create_vlan_from_pif_pool.rb
+++ b/lib/fog/compute/xen_server/requests/create_vlan_from_pif_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def create_vlan_from_pif_pool(pif, network, vlan)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.create_VLAN_from_PIF' }, pif, network, vlan)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/create_vlan_pool.rb
+++ b/lib/fog/compute/xen_server/requests/create_vlan_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def create_vlan_pool(device, network, vlan)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.create_VLAN' }, device, network, vlan)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/crl_install_pool.rb
+++ b/lib/fog/compute/xen_server/requests/crl_install_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def crl_install_pool(name, cert)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.crl_install' }, name, cert)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/crl_list_pool.rb
+++ b/lib/fog/compute/xen_server/requests/crl_list_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def crl_list_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.crl_list')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/crl_uninstall_pool.rb
+++ b/lib/fog/compute/xen_server/requests/crl_uninstall_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def crl_uninstall_pool(name)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.crl_uninstall' }, name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/designate_new_master_pool.rb
+++ b/lib/fog/compute/xen_server/requests/designate_new_master_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def designate_new_master_pool(host)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.designate_new_master' }, host)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/detect_nonhomogeneous_external_auth_pool.rb
+++ b/lib/fog/compute/xen_server/requests/detect_nonhomogeneous_external_auth_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def detect_nonhomogeneous_external_auth_pool(ref)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.detect_nonhomogeneous_external_auth' }, ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/disable_external_auth_pool.rb
+++ b/lib/fog/compute/xen_server/requests/disable_external_auth_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def disable_external_auth_pool(ref, config)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.disable_external_auth' }, ref, config)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/disable_ha_pool.rb
+++ b/lib/fog/compute/xen_server/requests/disable_ha_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def disable_ha_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.disable_ha')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/disable_local_storage_caching_pool.rb
+++ b/lib/fog/compute/xen_server/requests/disable_local_storage_caching_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def disable_local_storage_caching_pool(ref)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.disable_local_storage_caching' }, ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/disable_redo_log_pool.rb
+++ b/lib/fog/compute/xen_server/requests/disable_redo_log_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def disable_redo_log_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.disable_redo_log')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/eject_pool.rb
+++ b/lib/fog/compute/xen_server/requests/eject_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def eject_pool(ref)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.eject' }, ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/emergency_reset_master_pool.rb
+++ b/lib/fog/compute/xen_server/requests/emergency_reset_master_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def emergency_reset_master_pool(master_address)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.emergency_reset_master' }, master_address)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/emergency_transition_to_master_pool.rb
+++ b/lib/fog/compute/xen_server/requests/emergency_transition_to_master_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def emergency_transition_to_master_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.emergency_transition_to_master')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/enable_external_auth_pool.rb
+++ b/lib/fog/compute/xen_server/requests/enable_external_auth_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def enable_external_auth_pool(ref, config, service_name, auth_type)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.enable_external_auth' }, ref, config, service_name, auth_type)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/enable_ha_pool.rb
+++ b/lib/fog/compute/xen_server/requests/enable_ha_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def enable_ha_pool(heartbeat_srs, configuration)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.enable_ha' }, heartbeat_srs, configuration)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/enable_local_storage_caching_pool.rb
+++ b/lib/fog/compute/xen_server/requests/enable_local_storage_caching_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def enable_local_storage_caching_pool(ref)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.enable_local_storage_caching' }, ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/enable_redo_log_pool.rb
+++ b/lib/fog/compute/xen_server/requests/enable_redo_log_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def enable_redo_log_pool(sr)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.enable_redo_log' }, sr)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/get_license_state_pool.rb
+++ b/lib/fog/compute/xen_server/requests/get_license_state_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def get_license_state_pool(ref)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.get_license_state' }, ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/ha_compute_hypothetical_max_host_failures_to_tolerate_pool.rb
+++ b/lib/fog/compute/xen_server/requests/ha_compute_hypothetical_max_host_failures_to_tolerate_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def ha_compute_hypothetical_max_host_failures_to_tolerate_pool(configuration)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.ha_compute_hypothetical_max_host_failures_to_tolerate' }, configuration)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/ha_compute_max_host_failures_to_tolerate_pool.rb
+++ b/lib/fog/compute/xen_server/requests/ha_compute_max_host_failures_to_tolerate_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def ha_compute_max_host_failures_to_tolerate_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.ha_compute_max_host_failures_to_tolerate')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/ha_compute_vm_failover_plan_pool.rb
+++ b/lib/fog/compute/xen_server/requests/ha_compute_vm_failover_plan_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def ha_compute_vm_failover_plan_pool(failed_hosts, failed_vms)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.ha_compute_vm_failover_plan' }, failed_hosts, failed_vms)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/ha_failover_plan_exists_pool.rb
+++ b/lib/fog/compute/xen_server/requests/ha_failover_plan_exists_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def ha_failover_plan_exists_pool(n)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.ha_failover_plan_exists' }, n)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/ha_prevent_restarts_for_pool.rb
+++ b/lib/fog/compute/xen_server/requests/ha_prevent_restarts_for_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def ha_prevent_restarts_for_pool(seconds)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.ha_prevent_restarts_for' }, seconds)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/join_force_pool.rb
+++ b/lib/fog/compute/xen_server/requests/join_force_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def join_force_pool(master_address, master_username, master_password)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.join_force' }, master_address, master_username, master_password)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/join_pool.rb
+++ b/lib/fog/compute/xen_server/requests/join_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def join_pool(master_address, master_username, master_password)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.join' }, master_address, master_username, master_password)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/recover_slaves_pool.rb
+++ b/lib/fog/compute/xen_server/requests/recover_slaves_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def recover_slaves_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.recover_slaves')
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/send_test_post_pool.rb
+++ b/lib/fog/compute/xen_server/requests/send_test_post_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def send_test_post_pool(host, port, body)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.send_test_post' }, host, port, body)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/set_ha_host_failures_to_tolerate_pool.rb
+++ b/lib/fog/compute/xen_server/requests/set_ha_host_failures_to_tolerate_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def set_ha_host_failures_to_tolerate_pool(ref, value)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.set_ha_host_failures_to_tolerate' }, ref, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/set_vswitch_controller_pool.rb
+++ b/lib/fog/compute/xen_server/requests/set_vswitch_controller_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def set_vswitch_controller_pool(address)
+          @connection.request({ :parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.set_vswitch_controller' }, address)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/xen_server/requests/sync_database_pool.rb
+++ b/lib/fog/compute/xen_server/requests/sync_database_pool.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class XenServer
+      class Real
+        def sync_database_pool
+          @connection.request(:parser => Fog::Parsers::XenServer::Base.new, :method => 'pool.sync_database')
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/sync_database_pool.yml
+++ b/spec/cassettes/sync_database_pool.yml
@@ -1,0 +1,129 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://192.168.10.2/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" ?><methodCall><methodName>session.login_with_password</methodName><params><param><value><string>root</string></value></param><param><value><string>123456</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 2.1.2)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '221'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '251'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - text/xml
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+    body:
+      encoding: UTF-8
+      string: "<methodResponse><params><param><value><struct><member><name>Status</name><value>Success</value></member><member><name>Value</name><value>OpaqueRef:cc5148e7-14a1-f637-fcdb-440fc6dedc0d</value></member></struct></value></param></params></methodResponse>"
+    http_version: 
+  recorded_at: Sat, 22 Nov 2014 13:59:41 GMT
+- request:
+    method: post
+    uri: http://192.168.10.2/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" ?><methodCall><methodName>pool.get_all_records</methodName><params><param><value><string>OpaqueRef:cc5148e7-14a1-f637-fcdb-440fc6dedc0d</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 2.1.2)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '203'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '4694'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - text/xml
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+    body:
+      encoding: UTF-8
+      string: "<methodResponse><params><param><value><struct><member><name>Status</name><value>Success</value></member><member><name>Value</name><value><struct><member><name>OpaqueRef:caf17d60-ed75-0deb-399f-4a3974620cbe</name><value><struct><member><name>uuid</name><value>51766268-0930-4d17-6aa0-fb7695242de8</value></member><member><name>name_label</name><value/></member><member><name>name_description</name><value/></member><member><name>master</name><value>OpaqueRef:78c23dd4-4470-ed14-47e1-9a0e21a32814</value></member><member><name>default_SR</name><value>OpaqueRef:131d30ee-74ab-efcf-ee38-ec96222a36ba</value></member><member><name>suspend_image_SR</name><value>OpaqueRef:NULL</value></member><member><name>crash_dump_SR</name><value>OpaqueRef:NULL</value></member><member><name>other_config</name><value><struct><member><name>cpuid_feature_mask</name><value>ffffff7f-ffffffff-ffffffff-ffffffff</value></member><member><name>memory-ratio-hvm</name><value>0.25</value></member><member><name>memory-ratio-pv</name><value>0.25</value></member></struct></value></member><member><name>ha_enabled</name><value><boolean>0</boolean></value></member><member><name>ha_configuration</name><value><struct/></value></member><member><name>ha_statefiles</name><value><array><data/></array></value></member><member><name>ha_host_failures_to_tolerate</name><value>0</value></member><member><name>ha_plan_exists_for</name><value>0</value></member><member><name>ha_allow_overcommit</name><value><boolean>0</boolean></value></member><member><name>ha_overcommitted</name><value><boolean>0</boolean></value></member><member><name>blobs</name><value><struct/></value></member><member><name>tags</name><value><array><data/></array></value></member><member><name>gui_config</name><value><struct/></value></member><member><name>wlb_url</name><value/></member><member><name>wlb_username</name><value/></member><member><name>wlb_enabled</name><value><boolean>0</boolean></value></member><member><name>wlb_verify_cert</name><value><boolean>0</boolean></value></member><member><name>redo_log_enabled</name><value><boolean>0</boolean></value></member><member><name>redo_log_vdi</name><value>OpaqueRef:NULL</value></member><member><name>vswitch_controller</name><value/></member><member><name>restrictions</name><value><struct><member><name>restrict_vswitch_controller</name><value>false</value></member><member><name>restrict_lab</name><value>false</value></member><member><name>restrict_stage</name><value>false</value></member><member><name>restrict_storagelink</name><value>false</value></member><member><name>restrict_storagelink_site_recovery</name><value>false</value></member><member><name>restrict_web_selfservice</name><value>true</value></member><member><name>restrict_web_selfservice_manager</name><value>true</value></member><member><name>restrict_hotfix_apply</name><value>true</value></member><member><name>restrict_vlan</name><value>false</value></member><member><name>restrict_qos</name><value>false</value></member><member><name>restrict_pool_attached_storage</name><value>false</value></member><member><name>restrict_netapp</name><value>false</value></member><member><name>restrict_equalogic</name><value>false</value></member><member><name>restrict_pooling</name><value>false</value></member><member><name>enable_xha</name><value>true</value></member><member><name>restrict_marathon</name><value>false</value></member><member><name>restrict_email_alerting</name><value>false</value></member><member><name>restrict_historical_performance</name><value>false</value></member><member><name>restrict_wlb</name><value>true</value></member><member><name>restrict_rbac</name><value>false</value></member><member><name>restrict_dmc</name><value>false</value></member><member><name>restrict_checkpoint</name><value>false</value></member><member><name>restrict_cpu_masking</name><value>false</value></member><member><name>restrict_connection</name><value>false</value></member><member><name>platform_filter</name><value>false</value></member><member><name>regular_nag_dialog</name><value>false</value></member><member><name>restrict_vmpr</name><value>false</value></member><member><name>restrict_intellicache</name><value>false</value></member><member><name>restrict_gpu</name><value>false</value></member><member><name>restrict_dr</name><value>false</value></member><member><name>restrict_vif_locking</name><value>false</value></member><member><name>restrict_storage_xen_motion</name><value>false</value></member></struct></value></member><member><name>metadata_VDIs</name><value><array><data/></array></value></member></struct></value></member></struct></value></member></struct></value></param></params></methodResponse>"
+    http_version: 
+  recorded_at: Sat, 22 Nov 2014 13:59:41 GMT
+- request:
+    method: post
+    uri: http://192.168.10.2/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" ?><methodCall><methodName>pool.sync_database</methodName><params><param><value><string>OpaqueRef:cc5148e7-14a1-f637-fcdb-440fc6dedc0d</string></value></param></params></methodCall>
+    headers:
+      User-Agent:
+      - XMLRPC::Client (Ruby 2.1.2)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '201'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '198'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - text/xml
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+    body:
+      encoding: UTF-8
+      string: "<methodResponse><params><param><value><struct><member><name>Status</name><value>Success</value></member><member><name>Value</name><value/></member></struct></value></param></params></methodResponse>"
+    http_version: 
+  recorded_at: Sat, 22 Nov 2014 13:59:41 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fog/compute/xen_server/requests/sync_database_pool_spec.rb
+++ b/spec/fog/compute/xen_server/requests/sync_database_pool_spec.rb
@@ -1,0 +1,16 @@
+require 'minitest_helper'
+
+describe "#sync_database_pool" do
+  let(:connection) do
+    Fog::Compute.new(:provider => 'XenServer',
+                     :xenserver_url => '192.168.10.2',
+                     :xenserver_username => 'root',
+                     :xenserver_password => '123456')
+  end
+
+  it "should return success" do
+    VCR.use_cassette('sync_database_pool') do
+      connection.pools.first.sync_database.size.must_equal 0
+    end
+  end
+end


### PR DESCRIPTION
- Metaprogramming on pool.rb is tested by sync_database_pool_spec.rb
- The define_method is not so cool, using that big array, but made
  this way to keep campatability with ruby 1.8.7 once this version
  has no `__callee__` method to check how is the original on alias

On ruby 1.9.3+ we can go this way:

``` ruby
def request_without_reference(*args)
  service.send("#{__callee__}_#{provider_class.downcase}", *args)
end
alias_method :method1, :request_without_reference
alias_method :method2, :request_without_reference
alias_method :method3, :request_without_reference
```

Last information, kept on pool.rb because an object like vm has no need
on calling requests without reference as first parameter, this will be
used on others objects (like host), but I opted to keep on each object
so don't need to change fog structure and each object can define its own
request call.
