### PR TITLE
Change revert to revert_to

### DIFF
--- a/lib/fog/compute/xen_server.rb
+++ b/lib/fog/compute/xen_server.rb
@@ -280,6 +280,7 @@ module Fog
       request :recover_server
       request :resume_on_server
       request :resume_server
+      request :revert_server	
       request :revert_to_server
       request :send_sysrq_server
       request :send_trigger_server


### PR DESCRIPTION
I noticed that in server.rb(1), line 168, you used revert_to_vm( alias_method to revert_to_server), but the request in xen_server.rb(2) was revert_server. Change it, because you said that revert will be deprecate.

https://github.com/fog/fog-xenserver/blob/master/lib/fog/compute/xen_server/models/server.rb#L168
https://github.com/fog/fog-xenserver/blob/master/lib/fog/compute/xen_server.rb#L283
