### PR TITLE
clone_vm/clone_server takes reference as first parameter

### DIFF
--- a/lib/fog/compute/xen_server/models/server.rb
+++ b/lib/fog/compute/xen_server/models/server.rb
@@ -154,7 +154,7 @@ module Fog
 
           def clone(name)
             raise "Clone Operation not Allowed" unless can_be_cloned?
-            self.reference = service.clone_vm(self.reference, name)
+            self.reference = service.clone_vm(reference, name)
             reload
           end
 

--- a/lib/fog/compute/xen_server/models/server.rb
+++ b/lib/fog/compute/xen_server/models/server.rb
@@ -154,7 +154,7 @@ module Fog
 
           def clone(name)
             raise "Clone Operation not Allowed" unless can_be_cloned?
-            self.reference = service.clone_vm(name, self.reference)
+            self.reference = service.clone_vm(self.reference, name)
             reload
           end
 

--- a/spec/fog/compute/xen_server/models/server_spec.rb
+++ b/spec/fog/compute/xen_server/models/server_spec.rb
@@ -508,7 +508,7 @@ describe Fog::Compute::XenServer::Models::Server do
     describe "when it can be cloned" do
       before :each do
         def server.can_be_cloned?; true end
-        def service.clone_vm(name, reference); @cloned = true end
+        def service.clone_vm(reference, name); @cloned = true end
         def server.reload; @reloaded = true end
         server.stub(:service, service) do
           server.clone('')

--- a/spec/fog/compute/xen_server/models/server_spec.rb
+++ b/spec/fog/compute/xen_server/models/server_spec.rb
@@ -508,7 +508,7 @@ describe Fog::Compute::XenServer::Models::Server do
     describe "when it can be cloned" do
       before :each do
         def server.can_be_cloned?; true end
-        def service.clone_vm(reference, name); @cloned = true end
+        def service.clone_vm(_reference, _name); @cloned = true end
         def server.reload; @reloaded = true end
         server.stub(:service, service) do
           server.clone('')


### PR DESCRIPTION
Server#clone called clone_vm with wrong parameter order causing
subsequent API call failure.