### PR TITLE
Add missing require statement.

### DIFF
--- a/lib/fog/xen_server/nokogiri_stream_parser.rb
+++ b/lib/fog/xen_server/nokogiri_stream_parser.rb
@@ -1,3 +1,4 @@
+require "xmlrpc/client"
 require "nokogiri/xml/sax/document"
 require "nokogiri/xml/sax/parser"
 


### PR DESCRIPTION
`Fog::XenServer::NokogiriStreamParser` relies on `xmprc/client` to have already been loaded. This normally happens by loading `Fog::XenServer::Connection` first, but that's not guaranteed to always be the case. Adding the extra require will fix relying on any particular load order.