### PR TITLE
Fixnum deprecated in Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,13 @@ matrix:
       gemfile: gemfiles/Gemfile.1.9.2+
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.1.9.2+
-    - rvm: 2.1.4
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile.1.9.2+
+    - rvm: 2.2.6
+      gemfile: gemfiles/Gemfile.1.9.2+
+    - rvm: 2.3.3
+      gemfile: gemfiles/Gemfile.1.9.2+
+    - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.1.9.2+
       env: COVERAGE=true
     - rvm: ree

--- a/fog-xenserver.gemspec
+++ b/fog-xenserver.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fog-xml'
   spec.add_dependency 'fog-core'
+  spec.add_dependency 'xmlrpc' if RUBY_VERSION =~ /^2\.[^0-3].*$/
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'json' if RUBY_VERSION =~ /^1\.8.*$/

--- a/lib/fog/utilities.rb
+++ b/lib/fog/utilities.rb
@@ -1,7 +1,7 @@
 class Hash
   def symbolize_keys!
     keys.each do |key|
-      self[(key.to_sym rescue key)] = delete(key) if key.respond_to?(:to_sym) && !key.is_a?(Fixnum)
+      self[key.to_sym] = delete(key) if key.respond_to?(:to_sym)
     end
     self
   end


### PR DESCRIPTION
Have gotten tired of waiting for PR #63 so I've patched it myself and have tested it against the full suite in PR #64 (however, this PR excludes those changes).

@plribeiro3000 makes an interesting point about the value of removing `symbolize_keys!` altogether, however, I felt that it would be best to push this out quickly and then take time to test for issues that arise from moving to string-based keys.