### PR TITLE
Bring the SSL support.

### DIFF
--- a/lib/fog/compute/xen_server.rb
+++ b/lib/fog/compute/xen_server.rb
@@ -12,6 +12,8 @@ module Fog
       requires :xenserver_url
       recognizes :xenserver_defaults
       recognizes :xenserver_timeout
+      recognizes :xenserver_use_ssl
+      recognizes :xenserver_port
 
       model_path "fog/compute/xen_server/models"
       model :blob

--- a/lib/fog/compute/xen_server/real.rb
+++ b/lib/fog/compute/xen_server/real.rb
@@ -10,7 +10,9 @@ module Fog
           @password    = options[:xenserver_password]
           @defaults    = options[:xenserver_defaults] || {}
           @timeout     = options[:xenserver_timeout] || 30
-          @connection  = Fog::XenServer::Connection.new(@host, @timeout)
+          @use_ssl     = options[:xenserver_use_ssl] || false
+          @port        = options[:xenserver_port] || true
+          @connection  = Fog::XenServer::Connection.new(@host, @port, @use_ssl, @timeout)
           @connection.authenticate(@username, @password)
         end
 

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -5,8 +5,8 @@ module Fog
     class Connection
       attr_reader :credentials
 
-      def initialize(host, timeout)
-        @factory = XMLRPC::Client.new(host, "/")
+      def initialize(host, port, use_ssl, timeout)
+        @factory = XMLRPC::Client.new(host, port = port, use_ssl = use_ssl, "/")
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout
       end


### PR DESCRIPTION
I'm using the latest `fog` and trying to make it work with my Xenserver instance.

My belief that the expectation is to use `http://` URL for connecting. I want to use HTTPS for this. Below change adds the support for this.

Unfortunately my XenServer is coming with a self-signed certificate, which breaks `XMLRPC::Client`, so I can't really test that. But from what I see, the change from below works.

I'll report on my efforts to test this.