### PR TITLE
Bring the SSL support (take 2)

### DIFF
--- a/lib/fog/compute/xen_server.rb
+++ b/lib/fog/compute/xen_server.rb
@@ -12,6 +12,8 @@ module Fog
       requires :xenserver_url
       recognizes :xenserver_defaults
       recognizes :xenserver_timeout
+      recognizes :xenserver_use_ssl
+      recognizes :xenserver_port
 
       model_path "fog/compute/xen_server/models"
       model :blob

--- a/lib/fog/compute/xen_server.rb
+++ b/lib/fog/compute/xen_server.rb
@@ -13,6 +13,7 @@ module Fog
       recognizes :xenserver_defaults
       recognizes :xenserver_timeout
       recognizes :xenserver_use_ssl
+      recognizes :xenserver_verify_mode
       recognizes :xenserver_port
 
       model_path "fog/compute/xen_server/models"

--- a/lib/fog/compute/xen_server/real.rb
+++ b/lib/fog/compute/xen_server/real.rb
@@ -12,7 +12,8 @@ module Fog
           @timeout     = options[:xenserver_timeout] || 30
           @use_ssl     = options[:xenserver_use_ssl] || false
           @port        = options[:xenserver_port] || 80
-          @connection  = Fog::XenServer::Connection.new(@host, @port, @use_ssl, @timeout)
+          @verify_mode = options[:xenserver_verify_mode] || OpenSSL::SSL::VERIFY_PEER
+          @connection  = Fog::XenServer::Connection.new(@host, @port, @use_ssl, @verify_mode, @timeout)
           @connection.authenticate(@username, @password)
         end
 

--- a/lib/fog/compute/xen_server/real.rb
+++ b/lib/fog/compute/xen_server/real.rb
@@ -11,7 +11,7 @@ module Fog
           @defaults    = options[:xenserver_defaults] || {}
           @timeout     = options[:xenserver_timeout] || 30
           @use_ssl     = options[:xenserver_use_ssl] || false
-          @port        = options[:xenserver_port] || true
+          @port        = options[:xenserver_port] || 80
           @connection  = Fog::XenServer::Connection.new(@host, @port, @use_ssl, @timeout)
           @connection.authenticate(@username, @password)
         end

--- a/lib/fog/compute/xen_server/real.rb
+++ b/lib/fog/compute/xen_server/real.rb
@@ -10,7 +10,9 @@ module Fog
           @password    = options[:xenserver_password]
           @defaults    = options[:xenserver_defaults] || {}
           @timeout     = options[:xenserver_timeout] || 30
-          @connection  = Fog::XenServer::Connection.new(@host, @timeout)
+          @use_ssl     = options[:xenserver_use_ssl] || false
+          @port        = options[:xenserver_port] || true
+          @connection  = Fog::XenServer::Connection.new(@host, @port, @use_ssl, @timeout)
           @connection.authenticate(@username, @password)
         end
 

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -6,7 +6,7 @@ module Fog
       attr_reader :credentials
 
       def initialize(host, port, use_ssl, timeout)
-        @factory = XMLRPC::Client.new(host, port = port, use_ssl = use_ssl, "/")
+        @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: use_ssl, path: "/")
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout
       end

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -6,7 +6,10 @@ module Fog
       attr_reader :credentials
 
       def initialize(host, port, use_ssl, timeout)
-        @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: use_ssl, path: "/")
+        @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: (use_ssl != false), path: "/")
+        if use_ssl == -1
+          @factory.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)
+        end
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout
       end

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -5,8 +5,8 @@ module Fog
     class Connection
       attr_reader :credentials
 
-      def initialize(host, timeout)
-        @factory = XMLRPC::Client.new(host, "/")
+      def initialize(host, port, use_ssl, timeout)
+        @factory = XMLRPC::Client.new(host, port = port, use_ssl = use_ssl, "/")
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout
       end

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -8,7 +8,7 @@ module Fog
       def initialize(host, port, use_ssl, timeout)
         @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: (use_ssl != false), path: "/")
         if use_ssl == -1
-          @factory.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)
+          @factory.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout

--- a/lib/fog/xen_server/connection.rb
+++ b/lib/fog/xen_server/connection.rb
@@ -5,11 +5,9 @@ module Fog
     class Connection
       attr_reader :credentials
 
-      def initialize(host, port, use_ssl, timeout)
-        @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: (use_ssl != false), path: "/")
-        if use_ssl == -1
-          @factory.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
+      def initialize(host, port, use_ssl, verify_mode, timeout)
+        @factory = XMLRPC::Client.new3(host: host, port: port, use_ssl: use_ssl, path: "/")
+        @factory.http.verify_mode = verify_mode
         @factory.set_parser(NokogiriStreamParser.new)
         @factory.timeout = timeout
       end


### PR DESCRIPTION
The expectation is to use http:// URL for connecting. I want to use HTTPS for this. Below change adds the support for this.


==
Unfortunately my XenServer is coming with a self-signed certificate, which breaks XMLRPC::Client, so I can't really test that.  With this, XMLRPC fails deep down in it's call graph. I'm testing with this line:
```
@factory.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)
```

put in the `initialize`  in `lib/fog/xen_server/connection.rb`, so that cert isn't checked.

If we could commit the change from below, and (maybe?) add a conditional work-around for the self-signed problem, that would be great.